### PR TITLE
Disable public sharing for demo launch

### DIFF
--- a/app/Wonder3D/gradio_app_mv.py
+++ b/app/Wonder3D/gradio_app_mv.py
@@ -432,7 +432,8 @@ def run_demo():
         #     process_3d, inputs=[mode, data_dir, scale_slider, crop_size], outputs=[obj_3d]
         # )
 
-        demo.queue().launch(share=True, max_threads=80)
+        # Publish the service to localhost only 
+        demo.queue().launch(share=False, max_threads=80)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed demo launch to not share the service publicly.